### PR TITLE
Fixed rate limiter bug 

### DIFF
--- a/prexel-server/Cargo.toml
+++ b/prexel-server/Cargo.toml
@@ -13,6 +13,9 @@ actix-web = "3"
 actix-ratelimit = {version = "0.3.1", default-features = false, features=["memory"] }
 tokio = { version = "1.16.1", features = ["full"] }
 env_logger = "0.9.0"
+uuid = { version = "0.8", features = ["serde", "v4"] }
+base64 = "0.13.0"
+log = "0.4.16"
 
 [[bin]]
 name="prexel-server"

--- a/prexel-server/src/main.rs
+++ b/prexel-server/src/main.rs
@@ -1,10 +1,20 @@
 mod endpoints;
-mod services;
+mod middlewares;
 mod models;
+mod services;
 
+use crate::middlewares::rate_limiter::{
+    generate_rate_limit_id, get_rate_limit_identifier, RATE_LIMIT_ID,
+};
+use actix_ratelimit::errors::ARError;
 use actix_ratelimit::{MemoryStore, MemoryStoreActor, RateLimiter};
-use actix_web::middleware::Logger;
-use actix_web::{ App, HttpResponse, HttpServer};
+use actix_web::cookie::{Cookie, CookieBuilder};
+use actix_web::dev::Service;
+use actix_web::http::header::{COOKIE, SET_COOKIE};
+use actix_web::http::{HeaderMap, HeaderValue};
+use actix_web::middleware::normalize::TrailingSlash;
+use actix_web::middleware::{Logger, NormalizePath};
+use actix_web::{App, HttpResponse, HttpServer};
 use std::env;
 use std::time::Duration;
 
@@ -12,12 +22,8 @@ pub type ApiResponse = Result<HttpResponse, HttpResponse>;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
+    env_logger::init_from_env(env_logger::Env::new().default_filter_or("debug"));
 
-    const MAX_REQUESTS : usize = 100;
-    const TIME_BETWEEN_REQUESTS : Duration = Duration::from_secs(60);
-
-    let store = MemoryStore::new();
     let port = env::var("PORT")
         .map(|s| s.parse::<u16>().ok())
         .ok()
@@ -27,17 +33,71 @@ async fn main() -> std::io::Result<()> {
     HttpServer::new(move || {
         App::new()
             .wrap(Logger::default())
-            .wrap(
-                RateLimiter::new(MemoryStoreActor::from(store.clone()).start())
-                    .with_interval(TIME_BETWEEN_REQUESTS)
-                    .with_max_requests(MAX_REQUESTS),
+            .wrap(NormalizePath::new(TrailingSlash::Trim))
+            .wrap(get_rate_limit_middleware())
+            .wrap_fn(|mut req, srv| {
+                let has_id = get_rate_limit_identifier(&req).is_some();
+                let mut cookie: Option<Cookie> = None;
+
+                if !has_id {
+                    let new_id = generate_rate_limit_id();
+                    log::debug!("Generating new rate limiter id for unknown ip: {}", new_id);
+                    let temp_cookie = CookieBuilder::new(RATE_LIMIT_ID, new_id)
+                        .http_only(true)
+                        .path("/")
+                        .permanent()
+                        .finish();
+
+                    // We need set the cookie to the request, to allow other middlewares to read it
+                    req.headers_mut().insert(
+                        COOKIE,
+                        HeaderValue::from_str(&temp_cookie.to_string()).unwrap(),
+                    );
+
+                    cookie = Some(temp_cookie);
+                }
+
+                let fut = srv.call(req);
+                async move {
+                    let mut res = fut.await?;
+
+                    if let Some(cookie) = cookie {
+                        let headers: &mut HeaderMap = res.headers_mut();
+
+                        // Set the cookie to the response
+                        headers.insert(
+                            SET_COOKIE,
+                            HeaderValue::from_str(&cookie.to_string()).unwrap(),
+                        );
+                    }
+
+                    Ok(res)
+                }
+            })
+            .service(
+                actix_web::web::scope("")
+                    .service(endpoints::eval)
+                    .service(endpoints::get_operators)
+                    .service(endpoints::get_functions)
+                    .service(endpoints::get_constants),
             )
-            .service(endpoints::eval)
-            .service(endpoints::get_operators)
-            .service(endpoints::get_functions)
-            .service(endpoints::get_constants)
     })
     .bind(format!("0.0.0.0:{}", port))?
     .run()
     .await
+}
+
+fn get_rate_limit_middleware() -> RateLimiter<MemoryStoreActor> {
+    const MAX_REQUESTS: usize = 100;
+    const TIME_BETWEEN_REQUESTS: Duration = Duration::from_secs(60);
+
+    let store = MemoryStore::new();
+
+    RateLimiter::new(MemoryStoreActor::from(store).start())
+        .with_interval(TIME_BETWEEN_REQUESTS)
+        .with_max_requests(MAX_REQUESTS)
+        .with_identifier(|req| match get_rate_limit_identifier(req) {
+            Some(id) => Ok(id),
+            None => Err(ARError::IdentificationError),
+        })
 }

--- a/prexel-server/src/middlewares/mod.rs
+++ b/prexel-server/src/middlewares/mod.rs
@@ -1,0 +1,1 @@
+pub mod rate_limiter;

--- a/prexel-server/src/middlewares/rate_limiter.rs
+++ b/prexel-server/src/middlewares/rate_limiter.rs
@@ -1,0 +1,35 @@
+use actix_web::dev::ServiceRequest;
+use actix_web::HttpMessage;
+use uuid::Uuid;
+
+pub const RATE_LIMIT_ID : &str = "X-Ratelimit-Id";
+
+pub fn get_rate_limit_identifier(req: &ServiceRequest) -> Option<String> {
+    fn internal_get_identifier(req: &ServiceRequest) -> Option<String> {
+        if let Some(remote_addr) = req.connection_info().remote_addr() {
+            return Some(remote_addr.to_string());
+        }
+
+        // FIXME: Peer address can be trick with a proxy
+        if let Some(peer_addr) = req.peer_addr() {
+            return Some(peer_addr.to_string());
+        }
+
+        if let Some(cookie) = req.cookie(RATE_LIMIT_ID) {
+            if cookie.http_only().unwrap_or(true) {
+                return Some(cookie.value().to_string());
+            }
+        }
+
+        None
+    }
+
+    internal_get_identifier(req).map(|id| {
+        base64::encode(id).trim_end_matches('=').to_string()
+    })
+}
+
+pub fn generate_rate_limit_id() -> String {
+    let uuid = Uuid::new_v4();
+    base64::encode(uuid.as_bytes()).trim_end_matches('=').to_string()
+}

--- a/prexel-server/src/services/evaluator.rs
+++ b/prexel-server/src/services/evaluator.rs
@@ -16,7 +16,7 @@ static CONFIG: Lazy<Config> = Lazy::new(|| {
 });
 
 pub fn eval_expression(expression: EvalExpression) -> EvalResult {
-    let r#type = expression.r#type.clone().unwrap_or(NumberType::Decimal);
+    let r#type = expression.r#type.unwrap_or(NumberType::Decimal);
 
     match r#type {
         NumberType::Decimal => eval_decimal_expression(expression),


### PR DESCRIPTION
When is behind a proxy like Heroku, the rate limiter fails to retrieve the Ip